### PR TITLE
Support for elixir function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Supported Languages
 7. VimL
 8. PL/SQL
 9. Zsh
+10. Elixir
 
 Installation
 ============
 
-Manual 
+Manual
 ------
 Copy the files plugin, ftplugin, doc, autoload directories into the related directories on your runtime path.
 

--- a/ftplugin/elixir/cfi.vim
+++ b/ftplugin/elixir/cfi.vim
@@ -1,0 +1,38 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_elixir')
+    finish
+endif
+let g:loaded_cfi_ftplugin_elixir = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+
+let s:BEGIN_PATTERN = '\C'.'^\s*'.'def\>'.'\s\+'.'\('.'[^(]\+'.'\)'.'\%('.'\s*'.'('.'\=\)'
+
+let s:finder = cfi#create_finder('elixir')
+
+function! s:finder.find(ctx) "{{{
+    let NONE = ''
+
+    if search(s:BEGIN_PATTERN, 'bW') == 0
+        return NONE
+    endif
+
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+
+    return m[1]
+endfunction "}}}
+
+call cfi#register_simple_finder('elixir', s:finder)
+unlet s:finder
+
+let &cpo = s:save_cpo
+


### PR DESCRIPTION
#### Changes:
- [x] Adds the support for elixir function
- [x] Updated the readme

Since ruby and elixir has similar syntax I have just copied from ruby/cfi.vim and renamed few things. Seems to be working with all variation of the function.

```elixir
  def greet(%{age: age}) when 6 < age and age < 12, do: "Hiya"
  def greet(%{age: age}) when 12 < age and age < 18, do: "Whatever"
  def greet(%{age: age}) when 60 < age, do: "You kids get off my lawn"
  def greet(_), do: "Hello"
  def greet do
    "Hello"
  end
```