### PR TITLE
Reimplement python parsing to account for nested functions/classes

### DIFF
--- a/ftplugin/python/cfi.vim
+++ b/ftplugin/python/cfi.vim
@@ -30,7 +30,7 @@ function! s:finder.find(ctx) "{{{
         endif
 
         let decl_indent_num = indent(prevnonblank('.'))
-        if decl_indent_num < indent_num
+        if decl_indent_num < indent_num || len(namespace) == 0
             let m = matchlist(getline(decl_pos), s:BEGIN_PATTERN)
             let indent_num = decl_indent_num
             call insert(namespace, m[2])

--- a/ftplugin/python/cfi.vim
+++ b/ftplugin/python/cfi.vim
@@ -21,7 +21,8 @@ let s:finder = cfi#create_finder('python')
 function! s:finder.find(ctx) "{{{
     let save_view = winsaveview()
 
-    let indent_num = indent(prevnonblank('.'))
+    let ini_pos = prevnonblank('.')
+    let indent_num = indent(ini_pos)
     let namespace = []
     while 1
         let decl_pos = search(s:BEGIN_PATTERN, 'bW')
@@ -30,7 +31,7 @@ function! s:finder.find(ctx) "{{{
         endif
 
         let decl_indent_num = indent(prevnonblank('.'))
-        if decl_indent_num < indent_num || len(namespace) == 0
+        if decl_indent_num < indent_num || (len(namespace) == 0 && ini_pos == decl_pos)
             let m = matchlist(getline(decl_pos), s:BEGIN_PATTERN)
             let indent_num = decl_indent_num
             call insert(namespace, m[2])

--- a/ftplugin/python/cfi.vim
+++ b/ftplugin/python/cfi.vim
@@ -42,51 +42,6 @@ function! s:finder.find(ctx) "{{{
     return join(namespace, '.')
 endfunction "}}}
 
-function! s:get_indent_num(lnum) "{{{
-    let lnum = a:lnum
-    if lnum == "."
-        let lnum = line(lnum)
-    endif
-    if lnum == 0
-        return 0
-    endif
-    if match(getline(lnum), '^[ \t]*$') >= 0
-        return s:get_indent_num(lnum - 1)
-    endif
-    return strlen(matchstr(getline(lnum), '^[ \t]*'))
-endfunction "}}}
-
-function! s:get_multiline_string_range(search_begin, search_end) "{{{
-    let MULTI_STR_RX = '\%('.'"""'.'\|'."'''".'\)'
-    let range = []
-
-    while 1
-        " begin of multi string
-        let begin = search(MULTI_STR_RX, 'W')
-        if begin == 0 || !(a:search_begin <= begin && begin <= a:search_end)
-            return range
-        endif
-        " end of multi string
-        let end = search(MULTI_STR_RX, 'W')
-        if end == 0 || !(a:search_begin <= end && end <= a:search_end)
-            return range
-        endif
-
-        call add(range, [begin, end])
-    endwhile
-endfunction "}}}
-
-function! s:in_multiline_string(range, lnum) "{{{
-    " Ignore `begin` and `end` lnum.
-    " Because they are lnums where """ or ''' is.
-    for [begin, end] in a:range
-        if begin < a:lnum && a:lnum < end
-            return 1
-        endif
-    endfor
-    return 0
-endfunction "}}}
-
 call cfi#register_simple_finder('python', s:finder)
 unlet s:finder
 


### PR DESCRIPTION
The previous implementation did not work properly when there were empty
lines between blocks of code inside a function.

I reimplemented it so:

  * indent detection is robust against empty lines: if it finds an empty
  line (or only whitespace), it returns the indent level of the previous
  line
  * function name detection moves upwards in the file until the
  beginning of the file, and keeps track of every enclosing declaration

Now the output returned shows the fully qualified function name
(MyClass.my_function) if it applies