### PR TITLE
Bash & sh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Supported Languages
 6. Ruby
 7. VimL
 8. PL/SQL
-9. Zsh
+9. sh, Bash, Zsh
 10. Elixir
 
 Installation

--- a/autoload/cfi.vim
+++ b/autoload/cfi.vim
@@ -127,7 +127,11 @@ function! cfi#register_simple_finder(filetype, finder) "{{{
     let s:finder[a:filetype] = a:finder
 endfunction "}}}
 
-
+function! cfi#get_finder(filetype) "{{{
+	if has_key(s:finder, a:filetype)
+		return s:finder[a:filetype]
+	endif
+endfunction "}}}
 
 " s:base_finder {{{
 let s:base_finder = {}

--- a/doc/cfi.txt
+++ b/doc/cfi.txt
@@ -75,6 +75,10 @@ cfi#supported_filetypes({filetype})				*cfi#supported_filetypes()*
 	If {filetype} is dot-separeted,
 	return true if all filetypes are supported.
 
+cfi#get_finder({filetype})					*cfi#get_finder()*
+	Return finder object for given filetype if it's supported,
+	or 0 if not
+
 }}}
 ------------------------------------------------------------------------------
 VARIABLES					*cfi-variables* {{{

--- a/ftplugin/bash/cfi.vim
+++ b/ftplugin/bash/cfi.vim
@@ -2,4 +2,4 @@
 scriptencoding utf-8
 
 runtime! ftplugin/sh/cfi.vim
-call cfi#register_simple_finder('zsh', cfi#get_finder('sh'))
+cfi#register_finder('bash', cfi#get_finder('sh'))

--- a/ftplugin/sh/cfi.vim
+++ b/ftplugin/sh/cfi.vim
@@ -1,0 +1,39 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_sh')
+    finish
+endif
+let g:loaded_cfi_ftplugin_sh = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+let s:BEGIN_PATTERN = '\C'.'^\s*'.'\%(function\s\+\)\?'.'\(\S\+\)'.'\s*()'
+let s:finder = cfi#create_finder('sh')
+
+function! s:finder.find(ctx) "{{{
+    let NONE = ''
+
+    if search(s:BEGIN_PATTERN, 'bW') == 0
+        return NONE
+    endif
+
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+
+    return m[1]
+endfunction "}}}
+
+call cfi#register_simple_finder('sh', s:finder)
+unlet s:finder
+
+
+
+
+let &cpo = s:save_cpo


### PR DESCRIPTION
I can't see why zsh finder can't be reused for (ba)sh.