### PR TITLE
Fix hanging up caused by uncompleted C language code

### DIFF
--- a/ftplugin/c/cfi.vim
+++ b/ftplugin/c/cfi.vim
@@ -54,7 +54,10 @@ function! s:finder.find_begin() "{{{
                     return NONE
                 endif
             endfor
-            if join(getline('.', '$'), '')[col('.') :] =~# '\s*[^;]'
+            if join(getline('.', '$'), '')[col('.') :] =~# '^\s*;'
+                " Function declaration
+                return NONE
+            else
                 let self.temp.funcname = funcname
                 break
             endif


### PR DESCRIPTION
#3 で説明させていただいた issue の PR です。
#26 should be also fixed by this fix.

# issue
以下のような不完全な C 言語の構文で、s:finder.find_begin() が無限ループに陥る。
```
int main(void[EOF]
```

# cause
s:FUNCTION_PATTERN を後方検索し、`empty(synstack(line('.'), col('.')))` が true となったカーソル位置を関数名と判定するアルゴリズムだが、エラーチェックにより正しく関数と判定されなかった場合、`(` の位置から s:FUNCTION_PATTERN を後方検索するループに戻るため、無限ループに陥る。

# fix
`empty(synstack(line('.'), col('.')))` が true となった場合は現在位置に関数名があることは確定とし、エラーチェックをしたうえで問題がなければ現在位置の関数名を返すようにする。

# 具体的な修正の補足
`join(getline('.', '$'), '')[col('.') :] =~# '\s*[^;]'` の判定文は関数宣言を除く処理と思われるが、ほとんどのケースで true となる(恐らく意図しない動作？)。ただし問題のケースでは比較対象が EOF だけなので false となる。今回の修正としては、関数宣言の判定文を修正し、true の場合は `return NONE` する。そうでない場合は関数名を返す。